### PR TITLE
feat: upgrade all tools from server.tool() to server.registerTool() API

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -164,12 +164,18 @@ export const searchOutputSchema = z.object({
 
 export const importOutputSchema = z.object({
   ok: z.boolean(),
+  songId: z.string().optional(),
+  title: z.string().optional(),
+  method: z.enum(['rest_api', 'url_scheme']).optional(),
   onsong_result: z.string().optional(),
   warnings: z.array(z.string()).optional(),
 })
 
 export const exportOutputSchema = z.object({
-  exported_files: z.array(z.string()),
+  exported_files: z.array(z.string()).optional(),
+  content: z.string().optional(),
+  song_id: z.string().optional(),
+  method: z.enum(['rest_api', 'url_scheme']).optional(),
   warnings: z.array(z.string()).optional(),
 })
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -183,6 +183,51 @@ export const openOutputSchema = z.object({
   ok: z.boolean(),
 })
 
+export const setsListOutputSchema = z.object({
+  sets: z.array(
+    z.object({
+      id: z.string().optional(),
+      name: z.string(),
+      song_count: z.number().int().min(0),
+      archived: z.boolean(),
+      created_at: z.string().optional(),
+      updated_at: z.string().optional(),
+    })
+  ),
+  total_count: z.number().int().min(0),
+})
+
+export const setsGetOutputSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  archived: z.boolean(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  songs: z.array(
+    z.object({
+      id: z.string().optional(),
+      title: z.string(),
+      artist: z.string().optional(),
+      key: z.string().optional(),
+      favorite: z.boolean().optional(),
+    })
+  ),
+})
+
+export const setsCreateOutputSchema = z.object({
+  ok: z.boolean(),
+  set: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+})
+
+export const setsAddSongOutputSchema = z.object({
+  ok: z.boolean(),
+  set_id: z.string(),
+  song_id: z.string(),
+})
+
 export const logLevelSchema = z.enum(['error', 'warn', 'info', 'debug', 'trace'])
 
 export const configSchema = z.object({
@@ -324,6 +369,10 @@ export type ImportOutput = z.infer<typeof importOutputSchema>
 export type ExportOutput = z.infer<typeof exportOutputSchema>
 export type ActionOutput = z.infer<typeof actionOutputSchema>
 export type OpenOutput = z.infer<typeof openOutputSchema>
+export type SetsListOutput = z.infer<typeof setsListOutputSchema>
+export type SetsGetOutput = z.infer<typeof setsGetOutputSchema>
+export type SetsCreateOutput = z.infer<typeof setsCreateOutputSchema>
+export type SetsAddSongOutput = z.infer<typeof setsAddSongOutputSchema>
 
 export type ApiAuthResponse = z.infer<typeof apiAuthResponseSchema>
 export type ApiPingResponse = z.infer<typeof apiPingResponseSchema>

--- a/src/tools/action.ts
+++ b/src/tools/action.ts
@@ -2,11 +2,13 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { UrlSchemeService } from '../services/url-scheme.js'
 import { mcpError, OnSongError, ErrorCodes } from '../lib/errors.js'
+import { actionOutputSchema } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_action_run'
+const TOOL_TITLE = 'Run OnSong Action'
 const TOOL_DESCRIPTION = 'Trigger a named OnSong action (next/previous song, scroll, pedal actions)'
 
-const inputSchema = {
+const inputSchema = z.object({
   action_name: z
     .string()
     .min(1)
@@ -15,43 +17,53 @@ const inputSchema = {
     .record(z.unknown())
     .optional()
     .describe('Action parameters (e.g., amount for scroll position)'),
-}
+})
 
 export function registerActionRunTool(server: McpServer): void {
   const urlScheme = new UrlSchemeService()
 
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    try {
-      if (!urlScheme.isSupported()) {
-        throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
-          message: 'URL schemes only supported on macOS',
-        })
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: actionOutputSchema,
+    },
+    async (args) => {
+      try {
+        if (!urlScheme.isSupported()) {
+          throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
+            message: 'URL schemes only supported on macOS',
+          })
+        }
+
+        const actionArgs = args.args
+
+        await urlScheme.runAction(args.action_name, actionArgs)
+
+        const isKnown = urlScheme.isKnownAction(args.action_name)
+        const warnings: string[] = []
+
+        if (!isKnown) {
+          warnings.push(
+            `Unknown action: ${args.action_name}. Known actions: ${urlScheme.getKnownActions().join(', ')}`
+          )
+        }
+
+        const result = {
+          ok: true,
+          performed_via: 'url_scheme' as const,
+          ...(warnings.length > 0 ? { warnings } : {}),
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      const actionArgs = args.args
-
-      await urlScheme.runAction(args.action_name, actionArgs)
-
-      const isKnown = urlScheme.isKnownAction(args.action_name)
-      const warnings: string[] = []
-
-      if (!isKnown) {
-        warnings.push(
-          `Unknown action: ${args.action_name}. Known actions: ${urlScheme.getKnownActions().join(', ')}`
-        )
-      }
-
-      const result = {
-        ok: true,
-        performed_via: 'url_scheme' as const,
-        ...(warnings.length > 0 ? { warnings } : {}),
-      }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }

--- a/src/tools/connect.ts
+++ b/src/tools/connect.ts
@@ -2,40 +2,52 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { createAuthenticatedClient } from '../services/client-factory.js'
 import { mcpError } from '../lib/errors.js'
+import { connectTestOutputSchema } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_connect_test'
+const TOOL_TITLE = 'Test OnSong Connection'
 const TOOL_DESCRIPTION = 'Validate that a chosen OnSong device is reachable and authenticated'
 
-const inputSchema = {
+const inputSchema = z.object({
   host: z.string().min(1).describe('Target host IP or hostname'),
   port: z.number().int().min(1).max(65535).describe('Target port number'),
-}
+})
 
 export function registerConnectTestTool(server: McpServer): void {
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient({ host: args.host, port: args.port })
-      const pingResult = await client.ping()
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: connectTestOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient({ host: args.host, port: args.port })
+        const pingResult = await client.ping()
 
-      const result = {
-        ok: true,
-        version: pingResult.pong,
-        capabilities: {
-          connectState: true,
-          connectSearch: true,
-          connectSets: true,
-          urlImport: true,
-          urlExport: true,
-          urlActions: true,
-          urlOpen: true,
-        },
-      }
+        const result = {
+          ok: true,
+          version: pingResult.pong,
+          capabilities: {
+            connectState: true,
+            connectSearch: true,
+            connectSets: true,
+            urlImport: true,
+            urlExport: true,
+            urlActions: true,
+            urlOpen: true,
+          },
+        }
 
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }

--- a/src/tools/discover.ts
+++ b/src/tools/discover.ts
@@ -1,11 +1,13 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { DiscoveryService } from '../services/discovery.js'
+import { discoverOutputSchema } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_discover'
+const TOOL_TITLE = 'Discover OnSong Devices'
 const TOOL_DESCRIPTION = 'Discover OnSong Connect servers on the local network via Bonjour/mDNS'
 
-const inputSchema = {
+const inputSchema = z.object({
   timeout_ms: z
     .number()
     .int()
@@ -13,15 +15,26 @@ const inputSchema = {
     .max(30000)
     .default(2000)
     .describe('Discovery timeout in milliseconds'),
-}
+})
 
 export function registerDiscoverTool(server: McpServer, discovery: DiscoveryService): void {
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    const timeoutMs = args.timeout_ms ?? 2000
-    const devices = await discovery.discover(timeoutMs)
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: discoverOutputSchema,
+    },
+    async (args) => {
+      const timeoutMs = args.timeout_ms ?? 2000
+      const devices = await discovery.discover(timeoutMs)
+      const result = { devices }
 
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify({ devices }, null, 2) }],
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        structuredContent: result,
+      }
     }
-  })
+  )
 }

--- a/src/tools/import.ts
+++ b/src/tools/import.ts
@@ -5,96 +5,100 @@ import { z } from 'zod'
 import { UrlSchemeService } from '../services/url-scheme.js'
 import { createAuthenticatedClient } from '../services/client-factory.js'
 import { mcpError, OnSongError, ErrorCodes } from '../lib/errors.js'
+import { importOutputSchema, targetSchema } from '../lib/schemas.js'
 import type { Config } from '../lib/schemas.js'
-import { targetSchema } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_library_import'
+const TOOL_TITLE = 'Import Chart to OnSong'
 const TOOL_DESCRIPTION =
   'Import a chart file into OnSong. Use target for remote devices (REST API) or omit for local (URL scheme)'
 
-const inputSchema = {
+const inputSchema = z.object({
   target: targetSchema.optional().describe('Remote OnSong device to import to (uses REST API)'),
   file_path: z.string().optional().describe('Path to chart file to import'),
   content: z.string().optional().describe('Chart content in OnSong/ChordPro format'),
   content_base64: z.string().optional().describe('Base64-encoded chart content (for URL scheme)'),
   filename: z.string().optional().describe('Filename for base64 content'),
-}
+})
 
 export function registerImportTool(server: McpServer, config: Config): void {
   const urlScheme = new UrlSchemeService()
 
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    try {
-      if (config.enableImport !== true) {
-        throw new OnSongError(ErrorCodes.IMPORT_DISABLED, {
-          message: 'Import operations are disabled. Set enableImport: true in config.',
-        })
-      }
-
-      let content: string
-
-      const hasFilePath = args.file_path !== undefined
-      const hasContent = args.content !== undefined
-      const hasBase64 = args.content_base64 !== undefined
-      const sourceCount = [hasFilePath, hasContent, hasBase64].filter(Boolean).length
-
-      if (sourceCount !== 1) {
-        throw new OnSongError(ErrorCodes.INVALID_INPUT, {
-          message: 'Exactly one of file_path, content, or content_base64 must be provided',
-        })
-      }
-
-      if (hasFilePath && args.file_path !== undefined) {
-        try {
-          content = await readFile(args.file_path, 'utf-8')
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          throw new OnSongError(ErrorCodes.FILE_READ_ERROR, { path: args.file_path, message })
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: importOutputSchema,
+    },
+    async (args) => {
+      try {
+        if (config.enableImport !== true) {
+          throw new OnSongError(ErrorCodes.IMPORT_DISABLED, {
+            message: 'Import operations are disabled. Set enableImport: true in config.',
+          })
         }
-      } else if (hasContent && args.content !== undefined) {
-        content = args.content
-      } else if (hasBase64 && args.content_base64 !== undefined) {
-        content = Buffer.from(args.content_base64, 'base64').toString('utf-8')
-      } else {
-        throw new OnSongError(ErrorCodes.INVALID_INPUT, { message: 'No content source provided' })
-      }
 
-      if (args.target !== undefined) {
-        const client = await createAuthenticatedClient(args.target, 'OnSong MCP Server')
+        let content: string
 
-        const { songId, title } = await client.importSong(content)
+        const hasFilePath = args.file_path !== undefined
+        const hasContent = args.content !== undefined
+        const hasBase64 = args.content_base64 !== undefined
+        const sourceCount = [hasFilePath, hasContent, hasBase64].filter(Boolean).length
 
+        if (sourceCount !== 1) {
+          throw new OnSongError(ErrorCodes.INVALID_INPUT, {
+            message: 'Exactly one of file_path, content, or content_base64 must be provided',
+          })
+        }
+
+        if (hasFilePath && args.file_path !== undefined) {
+          try {
+            content = await readFile(args.file_path, 'utf-8')
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            throw new OnSongError(ErrorCodes.FILE_READ_ERROR, { path: args.file_path, message })
+          }
+        } else if (hasContent && args.content !== undefined) {
+          content = args.content
+        } else if (hasBase64 && args.content_base64 !== undefined) {
+          content = Buffer.from(args.content_base64, 'base64').toString('utf-8')
+        } else {
+          throw new OnSongError(ErrorCodes.INVALID_INPUT, { message: 'No content source provided' })
+        }
+
+        if (args.target !== undefined) {
+          const client = await createAuthenticatedClient(args.target, 'OnSong MCP Server')
+
+          const { songId, title } = await client.importSong(content)
+
+          const result = { ok: true, songId, title, method: 'rest_api' }
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          }
+        }
+
+        if (!urlScheme.isSupported()) {
+          throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
+            message: 'URL schemes only supported on macOS. Provide target for remote import.',
+          })
+        }
+
+        const filename = args.filename ?? basename(args.file_path ?? 'imported.onsong')
+        const base64Content = Buffer.from(content).toString('base64')
+
+        await urlScheme.importChart(filename, base64Content)
+
+        const result = { ok: true, method: 'url_scheme' }
         return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ ok: true, songId, title, method: 'rest_api' }, null, 2),
-            },
-          ],
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
         }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      if (!urlScheme.isSupported()) {
-        throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
-          message: 'URL schemes only supported on macOS. Provide target for remote import.',
-        })
-      }
-
-      const filename = args.filename ?? basename(args.file_path ?? 'imported.onsong')
-      const base64Content = Buffer.from(content).toString('base64')
-
-      await urlScheme.importChart(filename, base64Content)
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({ ok: true, method: 'url_scheme' }, null, 2),
-          },
-        ],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }

--- a/src/tools/open.ts
+++ b/src/tools/open.ts
@@ -2,39 +2,51 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { UrlSchemeService } from '../services/url-scheme.js'
 import { mcpError, OnSongError, ErrorCodes } from '../lib/errors.js'
+import { openOutputSchema } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_open'
+const TOOL_TITLE = 'Open in OnSong'
 const TOOL_DESCRIPTION = 'Open a specific song or set in OnSong'
 
-const inputSchema = {
+const inputSchema = z.object({
   type: z.enum(['song', 'set']).describe('What to open'),
   identifier: z.string().min(1).describe('Song or set name/ID'),
-}
+})
 
 export function registerOpenTool(server: McpServer): void {
   const urlScheme = new UrlSchemeService()
 
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    try {
-      if (!urlScheme.isSupported()) {
-        throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
-          message: 'URL schemes only supported on macOS',
-        })
-      }
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: openOutputSchema,
+    },
+    async (args) => {
+      try {
+        if (!urlScheme.isSupported()) {
+          throw new OnSongError(ErrorCodes.URL_SCHEME_UNSUPPORTED, {
+            message: 'URL schemes only supported on macOS',
+          })
+        }
 
-      if (args.type === 'song') {
-        await urlScheme.openSong(args.identifier)
-      } else {
-        await urlScheme.openSet(args.identifier)
-      }
+        if (args.type === 'song') {
+          await urlScheme.openSong(args.identifier)
+        } else {
+          await urlScheme.openSet(args.identifier)
+        }
 
-      const result = { ok: true }
+        const result = { ok: true }
 
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,24 +2,20 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { createAuthenticatedClient } from '../services/client-factory.js'
 import { mcpError } from '../lib/errors.js'
+import { searchOutputSchema, targetSchema } from '../lib/schemas.js'
 import type { ApiSongObject } from '../lib/schemas.js'
 
 const TOOL_NAME = 'onsong_library_search'
+const TOOL_TITLE = 'Search OnSong Library'
 const TOOL_DESCRIPTION = 'Search songs by title, artist, or text query'
 
-const targetSchema = z.object({
-  host: z.string().min(1),
-  port: z.number().int().min(1).max(65535),
-  token: z.string().min(32).optional(),
-})
-
-const inputSchema = {
+const inputSchema = z.object({
   target: targetSchema.describe('Connection target'),
   query: z.string().min(1).describe('Search query (matches title, artist, keywords, lyrics)'),
   limit: z.number().int().min(1).max(100).default(25).describe('Maximum results to return'),
-}
+})
 
-function transformSong(apiSong: ApiSongObject): object {
+function transformSong(apiSong: ApiSongObject): Record<string, unknown> {
   return {
     id: apiSong.ID,
     title: apiSong.title,
@@ -30,25 +26,35 @@ function transformSong(apiSong: ApiSongObject): object {
 }
 
 export function registerSearchTool(server: McpServer): void {
-  server.tool(TOOL_NAME, TOOL_DESCRIPTION, inputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient(args.target)
+  server.registerTool(
+    TOOL_NAME,
+    {
+      title: TOOL_TITLE,
+      description: TOOL_DESCRIPTION,
+      inputSchema,
+      outputSchema: searchOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient(args.target)
 
-      const searchResult = await client.searchSongs({
-        q: args.query,
-        limit: args.limit,
-      })
+        const searchResult = await client.searchSongs({
+          q: args.query,
+          limit: args.limit,
+        })
 
-      const result = {
-        songs: searchResult.results.map(transformSong),
-        total_count: searchResult.count,
+        const result = {
+          songs: searchResult.results.map(transformSong),
+          total_count: searchResult.count,
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }

--- a/src/tools/sets.ts
+++ b/src/tools/sets.ts
@@ -2,42 +2,52 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { createAuthenticatedClient } from '../services/client-factory.js'
 import { mcpError, OnSongError, ErrorCodes } from '../lib/errors.js'
-import { targetSchema } from '../lib/schemas.js'
+import {
+  targetSchema,
+  setsListOutputSchema,
+  setsGetOutputSchema,
+  setsCreateOutputSchema,
+  setsAddSongOutputSchema,
+} from '../lib/schemas.js'
 import type { ApiSetObject, ApiSongObject } from '../lib/schemas.js'
 
 const LIST_TOOL_NAME = 'onsong_sets_list'
+const LIST_TOOL_TITLE = 'List OnSong Sets'
 const LIST_TOOL_DESCRIPTION = 'List all sets in the OnSong library'
 
 const CREATE_TOOL_NAME = 'onsong_sets_create'
+const CREATE_TOOL_TITLE = 'Create OnSong Set'
 const CREATE_TOOL_DESCRIPTION = 'Create a new set in OnSong'
 
 const GET_TOOL_NAME = 'onsong_sets_get'
+const GET_TOOL_TITLE = 'Get OnSong Set'
 const GET_TOOL_DESCRIPTION = 'Get set details including songs'
 
 const ADD_SONG_TOOL_NAME = 'onsong_sets_add_song'
+const ADD_SONG_TOOL_TITLE = 'Add Song to Set'
 const ADD_SONG_TOOL_DESCRIPTION = 'Add a song to a set'
 
-const listInputSchema = {
+const listInputSchema = z.object({
   target: targetSchema.describe('Connection target'),
-}
+})
 
-const createInputSchema = {
+const createInputSchema = z.object({
   target: targetSchema.describe('Connection target'),
   name: z.string().min(1).describe('Name for the new set'),
-}
+})
 
-const getInputSchema = {
+const getInputSchema = z.object({
   target: targetSchema.describe('Connection target'),
   set_id: z.string().min(1).describe('Set ID to retrieve'),
-}
+})
 
-const addSongInputSchema = {
+const addSongInputSchema = z.object({
   target: targetSchema.describe('Connection target'),
   set_id: z.string().min(1).describe('Set ID to add song to'),
   song_id: z.string().min(1).describe('Song ID to add'),
-}
+})
 
-function transformSet(apiSet: ApiSetObject): object {
+function transformSet(apiSet: ApiSetObject): Record<string, unknown> {
   return {
     id: apiSet.ID,
     name: apiSet.name,
@@ -48,7 +58,7 @@ function transformSet(apiSet: ApiSetObject): object {
   }
 }
 
-function transformSong(apiSong: ApiSongObject): object {
+function transformSong(apiSong: ApiSongObject): Record<string, unknown> {
   return {
     id: apiSong.ID,
     title: apiSong.title,
@@ -59,87 +69,127 @@ function transformSong(apiSong: ApiSongObject): object {
 }
 
 export function registerSetsTools(server: McpServer): void {
-  server.tool(LIST_TOOL_NAME, LIST_TOOL_DESCRIPTION, listInputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient(args.target)
-      const setsResult = await client.listSets()
+  server.registerTool(
+    LIST_TOOL_NAME,
+    {
+      title: LIST_TOOL_TITLE,
+      description: LIST_TOOL_DESCRIPTION,
+      inputSchema: listInputSchema,
+      outputSchema: setsListOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient(args.target)
+        const setsResult = await client.listSets()
 
-      const result = {
-        sets: setsResult.results.map(transformSet),
-        total_count: setsResult.count,
-      }
+        const result = {
+          sets: setsResult.results.map(transformSet),
+          total_count: setsResult.count,
+        }
 
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 
-  server.tool(CREATE_TOOL_NAME, CREATE_TOOL_DESCRIPTION, createInputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient(args.target)
-      const createResult = await client.createSet(args.name)
+  server.registerTool(
+    CREATE_TOOL_NAME,
+    {
+      title: CREATE_TOOL_TITLE,
+      description: CREATE_TOOL_DESCRIPTION,
+      inputSchema: createInputSchema,
+      outputSchema: setsCreateOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient(args.target)
+        const createResult = await client.createSet(args.name)
 
-      if (createResult.success === undefined) {
-        throw new OnSongError(ErrorCodes.API_ERROR, { message: 'No set ID returned from create' })
+        if (createResult.success === undefined) {
+          throw new OnSongError(ErrorCodes.API_ERROR, { message: 'No set ID returned from create' })
+        }
+
+        const result = {
+          ok: true,
+          set: {
+            id: createResult.success.ID,
+            name: createResult.success.name,
+          },
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      const result = {
-        ok: true,
-        set: {
-          id: createResult.success.ID,
-          name: createResult.success.name,
-        },
-      }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 
-  server.tool(GET_TOOL_NAME, GET_TOOL_DESCRIPTION, getInputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient(args.target)
-      const setDetail = await client.getSet(args.set_id)
+  server.registerTool(
+    GET_TOOL_NAME,
+    {
+      title: GET_TOOL_TITLE,
+      description: GET_TOOL_DESCRIPTION,
+      inputSchema: getInputSchema,
+      outputSchema: setsGetOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient(args.target)
+        const setDetail = await client.getSet(args.set_id)
 
-      const result = {
-        id: setDetail.ID,
-        name: setDetail.name,
-        archived: setDetail.archived ?? false,
-        created_at: setDetail.dateCreated,
-        updated_at: setDetail.dateModified,
-        songs: (setDetail.songs ?? []).map(transformSong),
+        const result = {
+          id: setDetail.ID,
+          name: setDetail.name,
+          archived: setDetail.archived ?? false,
+          created_at: setDetail.dateCreated,
+          updated_at: setDetail.dateModified,
+          songs: (setDetail.songs ?? []).map(transformSong),
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 
-  server.tool(ADD_SONG_TOOL_NAME, ADD_SONG_TOOL_DESCRIPTION, addSongInputSchema, async (args) => {
-    try {
-      const client = await createAuthenticatedClient(args.target)
-      await client.addSongToSet(args.set_id, args.song_id)
+  server.registerTool(
+    ADD_SONG_TOOL_NAME,
+    {
+      title: ADD_SONG_TOOL_TITLE,
+      description: ADD_SONG_TOOL_DESCRIPTION,
+      inputSchema: addSongInputSchema,
+      outputSchema: setsAddSongOutputSchema,
+    },
+    async (args) => {
+      try {
+        const client = await createAuthenticatedClient(args.target)
+        await client.addSongToSet(args.set_id, args.song_id)
 
-      const result = {
-        ok: true,
-        set_id: args.set_id,
-        song_id: args.song_id,
+        const result = {
+          ok: true,
+          set_id: args.set_id,
+          song_id: args.song_id,
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        }
+      } catch (error) {
+        return mcpError(error)
       }
-
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-      }
-    } catch (error) {
-      return mcpError(error)
     }
-  })
+  )
 }


### PR DESCRIPTION
Migrate all 10 tool registrations to use the new registerTool() API which enables outputSchema, structuredContent, and tool titles. This addresses the deprecation of the old tool() method.

Changes:
- Add output schemas for sets tools (list, get, create, add_song)
- Convert inputSchema from plain objects to z.object() for all tools
- Add TOOL_TITLE constants and include in registerTool options
- Add structuredContent to all tool return values for typed responses
- Update transform functions to return Record<string, unknown> for TypeScript compatibility with MCP SDK types

Closes #5